### PR TITLE
remove tensorflow-addons dependency. Remove FScore metric from NNInte…

### DIFF
--- a/pandas/plotting/_matplotlib/__init__.py
+++ b/pandas/plotting/_matplotlib/__init__.py
@@ -2,16 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from typing import TYPE_CHECKING, Dict, Type
+
 from pandas.plotting._matplotlib.boxplot import (
     BoxPlot,
     boxplot,
     boxplot_frame,
     boxplot_frame_groupby,
 )
-from pandas.plotting._matplotlib.converter import (
-    deregister,
-    register,
-)
+from pandas.plotting._matplotlib.converter import deregister, register
 from pandas.plotting._matplotlib.core import (
     AreaPlot,
     BarhPlot,
@@ -21,12 +20,7 @@ from pandas.plotting._matplotlib.core import (
     PiePlot,
     ScatterPlot,
 )
-from pandas.plotting._matplotlib.hist import (
-    HistPlot,
-    KdePlot,
-    hist_frame,
-    hist_series,
-)
+from pandas.plotting._matplotlib.hist import HistPlot, KdePlot, hist_frame, hist_series
 from pandas.plotting._matplotlib.misc import (
     andrews_curves,
     autocorrelation_plot,
@@ -39,9 +33,9 @@ from pandas.plotting._matplotlib.misc import (
 from pandas.plotting._matplotlib.tools import table
 
 if TYPE_CHECKING:
-    from pandas.plotting._matplotlib.core import MPLPlot
+    from pandas.plotting._matplotlib.core import MPLPlot  # noqa: F401
 
-PLOT_CLASSES: dict[str, type[MPLPlot]] = {
+PLOT_CLASSES: Dict[str, Type["MPLPlot"]] = {
     "line": LinePlot,
     "bar": BarPlot,
     "barh": BarhPlot,
@@ -53,6 +47,45 @@ PLOT_CLASSES: dict[str, type[MPLPlot]] = {
     "scatter": ScatterPlot,
     "hexbin": HexBinPlot,
 }
+
+
+def plot(data, kind, **kwargs):
+    # Importing pyplot at the top of the file (before the converters are
+    # registered) causes problems in matplotlib 2 (converters seem to not
+    # work)
+    import matplotlib.pyplot as plt
+
+    if kwargs.pop("reuse_plot", False):
+        ax = kwargs.get("ax")
+        if ax is None and len(plt.get_fignums()) > 0:
+            with plt.rc_context():
+                ax = plt.gca()
+            kwargs["ax"] = getattr(ax, "left_ax", ax)
+    plot_obj = PLOT_CLASSES[kind](data, **kwargs)
+    plot_obj.generate()
+    plot_obj.draw()
+    return plot_obj.result
+
+
+__all__ = [
+    "plot",
+    "hist_series",
+    "hist_frame",
+    "boxplot",
+    "boxplot_frame",
+    "boxplot_frame_groupby",
+    "table",
+    "andrews_curves",
+    "autocorrelation_plot",
+    "bootstrap_plot",
+    "lag_plot",
+    "parallel_coordinates",
+    "radviz",
+    "scatter_matrix",
+    "register",
+    "deregister",
+]
+
 
 
 def plot(data, kind, **kwargs):


### PR DESCRIPTION
…rface

remove tensorflow-addons dependency. Remove FScore metric from NNInterface
plitted the pandas plotting module into a general plotting framework able to call different backends and the current matplotlib backends. The idea is that other backends can be implemented in a simpler way, and be used with a common API by pandas users.

The API defined by the current matplotlib backend includes the objects listed next, but this API can probably be simplified. Here is the list with questions/proposals:

- [x] closes #xxxx
- [x] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
